### PR TITLE
Add active endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You are now ready to hit a local instance of String Theory with Bruno
 
 ### Executing requests against other environments
 
-If you have a String Theory running somewher you can configure Bruno to be able to hit it using the following steps:
+If you have a String Theory running somewhere you can configure Bruno to be able to hit it using the following steps:
 
 1. Click on a collection
 2. In the top right corner there is a drop down that will say "local" or "No Environment"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+## String Theory API Tests
+
+This repository contains sample requests for the String Theory APIs (https://string-theory.finance/api).
+
+### Getting Started
+
+1. Clone this repository locally `git clone git@github.com:Ellisande/string-theory-bruno.git`
+2. Install Bruno (https://usebruno.com)
+3. Import the project into Bruno using the "open collection" function
+
+You are now ready to hit a local instance of String Theory with Bruno
+
+### Executing requests against other environments
+
+If you have a String Theory running somewher you can configure Bruno to be able to hit it using the following steps:
+
+1. Click on a collection
+2. In the top right corner there is a drop down that will say "local" or "No Environment"
+3. Click on the drop down and select "Configure"
+4. Press the "+Create" button to create a new environment, and give it a meaningful name
+5. Click "+Add Variable" and add a new variable called `base_url`, the value should be the root URL of your String Theory API instance
+6. Click "+Add variable" and add a new varaible called `api_key`, click the box that says "secret", and finally paste in your String Theory API key for the environment you intend to hit
+
+You are new ready to use Bruno for your custom environment!

--- a/README.md
+++ b/README.md
@@ -20,5 +20,7 @@ If you have a String Theory running somewher you can configure Bruno to be able 
 4. Press the "+Create" button to create a new environment, and give it a meaningful name
 5. Click "+Add Variable" and add a new variable called `base_url`, the value should be the root URL of your String Theory API instance
 6. Click "+Add variable" and add a new varaible called `api_key`, click the box that says "secret", and finally paste in your String Theory API key for the environment you intend to hit
+7. Click "save" to save the changes for your environment
+8. Click "active" to use this as your active environment for requests
 
 You are new ready to use Bruno for your custom environment!

--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ If you have a String Theory running somewhere you can configure Bruno to be able
 7. Click "save" to save the changes for your environment
 8. Click "active" to use this as your active environment for requests
 
-You are new ready to use Bruno for your custom environment!
+You are now ready to use Bruno for your custom environment!

--- a/beta/folder.bru
+++ b/beta/folder.bru
@@ -1,3 +1,7 @@
 meta {
   name: beta
 }
+
+headers {
+  x-api-key: {{api_key}}
+}

--- a/beta/loan - bulk.bru
+++ b/beta/loan - bulk.bru
@@ -1,0 +1,70 @@
+meta {
+  name: loan - bulk
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{base_url}}/v1/loan/group/bulk
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "source": {
+      "groupIntersection": [
+        {
+          "id": "group_01jv2x0xt5enbsvjp8t930hzb5"
+        }
+      ],
+      "owner": {
+        "type": "test_owner",
+        "id": "test_money_owner"
+      }
+    },
+    "destination": {
+      "commonGroups": [],
+      "commonTag": {},
+      "owner": {
+        "type": "test_owner",
+        "id": "destination_owner"
+      }
+    },
+    "loans": [
+      {
+        "amount": {
+          "unitType": "currency_micros",
+          "unitToken": "USD",
+          "unitCount": 100
+        }
+      }
+      // ,
+      // {
+      //     "amount": {
+      //         "unitType": "currency_micros",
+      //         "unitToken": "USD",
+      //         "unitCount": 200
+      //     }
+      // },
+      // {
+      //     "amount": {
+      //         "unitType": "currency_micros",
+      //         "unitToken": "USD",
+      //         "unitCount": 300
+      //     }
+      // }
+    ],
+    "actor": {
+      "type": "test_user",
+      "id": "bruno_api_test"
+    },
+    "actionData": {
+      // "sample": "actionData"
+    },
+    "idempotencyKey": {
+      "type": "test",
+      "token": "{{$guid}}"
+    }
+  }
+}

--- a/current/deposit - cancel.bru
+++ b/current/deposit - cancel.bru
@@ -1,7 +1,7 @@
 meta {
   name: deposit - cancel
   type: http
-  seq: 2
+  seq: 3
 }
 
 post {

--- a/current/deposit - cancel.bru
+++ b/current/deposit - cancel.bru
@@ -1,0 +1,62 @@
+meta {
+  name: deposit - cancel
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{base_url}}/v2/deposit/cancel
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+      "sources": {
+          "knotIds": [
+              "knot_01jv2wkp5wenbsvj2hfk1h7e9g",
+              "knot_01jv2wkydtenbsvj4g57qzyx03"
+          ],
+          "threadIds": [
+              // "thread_1234"
+          ],
+          "groupUnions": [
+              // {
+              //     "id": "group_1234"
+              // }
+          ],
+          "groupIntersections": [
+              // [
+              //     {
+              //         "id": "group_1234"
+              //     }
+              // ]
+          ]
+      },
+      "owner": {
+          "type": "test_owner",
+          "id": "test_money_owner"
+      },
+      "actor": {
+          "type": "test_user",
+          "id": "bruno_api_test"
+      },
+      "actionData": {
+          // "test_action_data": "one_time_information"
+      },
+      "tags": {
+          // "test_tag_1": "foo",
+          // "test_tag_2": "bar"
+      },
+      "groupsToAdd": [
+          // {
+          //     "type": "transfer",
+          //     "token": "two-phase"
+          // }
+      ],
+      "idempotencyKey": {
+          "type": "test",
+          "token": "{{$guid}}"
+      }
+  }
+}

--- a/current/deposit - confirm.bru
+++ b/current/deposit - confirm.bru
@@ -1,0 +1,62 @@
+meta {
+  name: deposit - confirm
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{base_url}}/v2/deposit/cancel
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+      "sources": {
+          "knotIds": [
+              "knot_01jv2wtc9eenbsvjb5xwmgge6s",
+              "knot_01jv2wtmcqenbsvjd7m9hr19dc"
+          ],
+          "threadIds": [
+              // "thread_1234"
+          ],
+          "groupUnions": [
+              // {
+              //     "id": "group_1234"
+              // }
+          ],
+          "groupIntersections": [
+              // [
+              //     {
+              //         "id": "group_1234"
+              //     }
+              // ]
+          ]
+      },
+      "owner": {
+          "type": "test_owner",
+          "id": "test_money_owner"
+      },
+      "actor": {
+          "type": "test_owner",
+          "id": "bruno_api_test"
+      },
+      "actionData": {
+          // "spicy": "peppers"
+      },
+      "tags": {
+          // "a": "b",
+          // "d": "e"
+      },
+      "groupsToAdd": [
+          // {
+          //     "type": "transfer",
+          //     "token": "two-phase"
+          // }
+      ],
+      "idempotencyKey": {
+          "type": "test",
+          "token": "{{$guid}}"
+      }
+  }
+}

--- a/current/deposit - debt.bru
+++ b/current/deposit - debt.bru
@@ -1,0 +1,63 @@
+meta {
+  name: deposit - debt
+  type: http
+  seq: 6
+}
+
+post {
+  url: {{base_url}}/v2/deposit/debt
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "deposits": [
+      {
+        "amount": {
+          "unitCount": -5000000000,
+          "unitToken": "USD",
+          "unitType": "currency_micros"
+        },
+        "tags": {
+          // "foo": "bar"
+        },
+        "groups": [
+          {
+            "type": "test_group_type_token",
+            "token": "a14d2e2e-230a-4271-a4f4-9b7253dbbce1"
+          }
+          //         ,
+          //         {
+          //           "id": "group_1kja93kajhsd0934a"
+          //         }
+        ]
+      }
+    ],
+    "owner": {
+      "type": "test_owner",
+      "id": "test_money_owner"
+    },
+    "actor": {
+      "type": "test_user",
+      "id": "bruno_api_test"
+    },
+    "actionData": {
+      // "spicy": "peppers"
+    },
+    "commonTags": {
+      // "a": "b",
+      // "d": "e"
+    },
+    "commonGroups": [
+      // {
+      //     "type": "transfer",
+      //     "token": "two-phase"
+      // }
+    ],
+    "idempotencyKey": {
+      "type": "test",
+      "token": "{{$guid}}"
+    }
+  }
+}

--- a/current/deposit - pending.bru
+++ b/current/deposit - pending.bru
@@ -1,7 +1,7 @@
 meta {
   name: deposit - pending
   type: http
-  seq: 3
+  seq: 2
 }
 
 post {

--- a/current/deposit - pending.bru
+++ b/current/deposit - pending.bru
@@ -1,0 +1,60 @@
+meta {
+  name: deposit - pending
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{base_url}}/v2/deposit/pending
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+      "deposits": [
+          {
+              "amount": {
+                  "unitCount": 5000000000,
+                  "unitToken": "USD",
+                  "unitType": "currency_micros"
+              },
+              "tags": {
+                  // "a": "b",
+                  // "d": "e"
+              },
+              "groups": [
+                  // {
+                  //     "type": "transfer",
+                  //     "token": "two-phase"
+                  // }
+              ]
+          }
+      ],
+      "owner": {
+          "type": "test_owner",
+          "id": "test_money_owner"
+      },
+      "actor": {
+          "type": "test_user",
+          "id": "bruno_api_test"
+      },
+      "actionData": {
+          // "spicy": "peppers"
+      },
+      "commonTags": {
+          // "a": "b",
+          // "d": "e"
+      },
+      "commonGroups": [
+          // {
+          //     "type": "transfer",
+          //     "token": "two-phase"
+          // }
+      ],
+      "idempotencyKey": {
+          "type": "test",
+          "token": "{{$guid}}"
+      }
+  }
+}

--- a/current/deposit - restore.bru
+++ b/current/deposit - restore.bru
@@ -1,0 +1,62 @@
+meta {
+  name: deposit - restore
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{base_url}}/v2/deposit/restore
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+      "sources": {
+          "knotIds": [
+              "knot_01jv2wkp5wenbsvj393zfpwff9",
+              "knot_01jv2wkydtenbsvj5f1z67d9nr"
+          ],
+          "threadIds": [
+              // "thread_1234"
+          ],
+          "groupUnions": [
+              // {
+              //     "id": "group_1234"
+              // }
+          ],
+          "groupIntersections": [
+              // [
+              //     {
+              //         "id": "group_1234"
+              //     }
+              // ]
+          ]
+      },
+      "owner": {
+          "type": "test_owner",
+          "id": "test_money_owner"
+      },
+      "actor": {
+          "type": "test_user",
+          "id": "bruno_api_test"
+      },
+      "actionData": {
+          // "spicy": "peppers"
+      },
+      "tags": {
+          // "a": "b",
+          // "d": "e"
+      },
+      "groupsToAdd": [
+          // {
+          //     "type": "transfer",
+          //     "token": "two-phase"
+          // }
+      ],
+      "idempotencyKey": {
+          "type": "test",
+          "token": "{{$guid}}"
+      }
+  }
+}

--- a/current/deposit.bru
+++ b/current/deposit.bru
@@ -23,14 +23,14 @@ body:json {
           // "foo": "bar"
         },
         "groups": [
-  //         {
-  //           "type": "test_group_type_token",
-  //           "token": "a14d2e2e-230a-4271-a4f4-9b7253dbbce1"
-  //         }
-  //         ,
-  //         {
-  //           "id": "group_1kja93kajhsd0934a"
-  //         }
+          {
+            "type": "test_group_type_token",
+            "token": "a14d2e2e-230a-4271-a4f4-9b7253dbbce1"
+          }
+          //         ,
+          //         {
+          //           "id": "group_1kja93kajhsd0934a"
+          //         }
         ]
       }
     ],

--- a/current/deposit.bru
+++ b/current/deposit.bru
@@ -36,7 +36,7 @@ body:json {
     ],
     "owner": {
       "type": "test_owner",
-      "id": "a14d2e2e-230a-4271-a4f4-9b7253dbbce1"
+      "id": "test_money_owner"
     },
     "actor": {
       "type": "test_user",

--- a/current/group - fetch by ids.bru
+++ b/current/group - fetch by ids.bru
@@ -1,7 +1,7 @@
 meta {
   name: group - fetch by ids
   type: http
-  seq: 6
+  seq: 7
 }
 
 post {

--- a/current/group - fetch by ids.bru
+++ b/current/group - fetch by ids.bru
@@ -1,0 +1,23 @@
+meta {
+  name: group - fetch by ids
+  type: http
+  seq: 6
+}
+
+post {
+  url: {{base_url}}/v2/groups
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "ids": [
+      "group_01jv2wxznhenbsvjh29zmjm9yq"
+    ]
+    // "owner": {
+    //     "type": "clerk_user",
+    //     "id": "user_2TDW6OsSPyju6AXgWJn8CtbzhoL"
+    // }
+  }
+}

--- a/current/group - search.bru
+++ b/current/group - search.bru
@@ -1,0 +1,21 @@
+meta {
+  name: group - search
+  type: http
+  seq: 7
+}
+
+post {
+  url: {{base_url}}/v2/groups/search
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+      "term": "test_group_type_token",
+      "owner": {
+          "type": "test_owner",
+          "id": "test_money_owner"
+      }
+  }
+}

--- a/current/group - search.bru
+++ b/current/group - search.bru
@@ -1,7 +1,7 @@
 meta {
   name: group - search
   type: http
-  seq: 7
+  seq: 8
 }
 
 post {

--- a/current/holds - add.bru
+++ b/current/holds - add.bru
@@ -1,0 +1,80 @@
+meta {
+  name: holds - add
+  type: http
+  seq: 8
+}
+
+post {
+  url: {{base_url}}/v2/hold/add
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "sources": {
+      "knotIds": [
+        "knot_01jv2z1pexenbsvjvkbqfcqt8r"
+      ],
+      "threadIds": [
+        // "thread_189fb9aecfb04fa88ff2ecf329c4ef96"
+      ],
+      "groupUnions": [
+        //       {
+        //         "type": "crazy",
+        //         "token": "rich"
+        //       }
+        //       ,
+        //       {
+        //         "id": "group_01hq1p0g2qf05tws1p21cswwea"
+        //       }
+      ],
+      "groupIntersections": [
+        //       [
+        //         {
+        //           "type": "crazy",
+        //           "token": "rich"
+        //         },
+        //         {
+        //           "id": "group_a69ee61425bf423cbb5647330b71c9f9"
+        //         }
+        //       ]
+      ]
+    },
+    "owner": {
+      "type": "test_owner",
+      "id": "test_money_owner"
+    },
+    "holds": [
+      {
+        "type": "fraud",
+        "token": "account_take_over"
+      }
+      //     ,
+      //     {
+      //       "id": "hold_1234"
+      //     }
+    ],
+    "actor": {
+      "type": "test_user",
+      "id": "bruno_api_test"
+    },
+    "groupsToAdd": [
+      // {
+      //     "type": "withdraw",
+      //     "token": "{{$guid}}"
+      // }
+    ],
+    "tags": {
+      // "a": "b",
+      // "d": "e"
+    },
+    "actionData": {
+      // "spicy": "peppers"
+    },
+    "idempotencyKey": {
+      "type": "test",
+      "token": "{{$guid}}"
+    }
+  }
+}

--- a/current/holds - add.bru
+++ b/current/holds - add.bru
@@ -1,7 +1,7 @@
 meta {
   name: holds - add
   type: http
-  seq: 8
+  seq: 9
 }
 
 post {

--- a/current/holds - alter tags.bru
+++ b/current/holds - alter tags.bru
@@ -1,0 +1,52 @@
+meta {
+  name: holds - alter tags
+  type: http
+  seq: 14
+}
+
+post {
+  url: {{base_url}}/v1/holds/tags/alter
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "holds": [
+      //         {
+      //             "type": "fraud",
+      //             "token": "account_take_over"
+      //         },
+      {
+        "id": "hold_01jv2z1pexenbsvjv2ngea65mt"
+      }
+    ],
+    "tagsToUpdate": {
+      "key2": "value2"
+    },
+    "tagsToRemove": {
+      "key1": "value1"
+    },
+    "groupsToAdd": [
+      // {
+      //     "type": "group1",
+      //     "token": "test1"
+      // }
+    ],
+    "owner": {
+      "type": "test_owner",
+      "id": "test_money_owner"
+    },
+    "actor": {
+      "type": "test_user",
+      "id": "bruno_api_test"
+    },
+    "actionData": {
+      // "spicy": "peppers"
+    },
+    "idempotencyKey": {
+      "type": "test",
+      "token": "{{$guid}}"
+    }
+  }
+}

--- a/current/holds - alter tags.bru
+++ b/current/holds - alter tags.bru
@@ -1,7 +1,7 @@
 meta {
   name: holds - alter tags
   type: http
-  seq: 14
+  seq: 15
 }
 
 post {

--- a/current/holds - create.bru
+++ b/current/holds - create.bru
@@ -1,0 +1,30 @@
+meta {
+  name: holds - create
+  type: http
+  seq: 10
+}
+
+post {
+  url: {{base_url}}/v1/hold/create
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "type": "test_fraud",
+    "token": "123",
+    "owner": {
+      "type": "test_owner",
+      "id": "test_money_owner"
+    },
+    "actor": {
+      "type": "test_user",
+      "id": "bruno_api_test"
+    },
+    "idempotencyKey": {
+      "type": "test",
+      "token": "{{$guid}}"
+    }
+  }
+}

--- a/current/holds - create.bru
+++ b/current/holds - create.bru
@@ -1,7 +1,7 @@
 meta {
   name: holds - create
   type: http
-  seq: 10
+  seq: 11
 }
 
 post {

--- a/current/holds - fetch by ids.bru
+++ b/current/holds - fetch by ids.bru
@@ -1,0 +1,23 @@
+meta {
+  name: holds - fetch by ids
+  type: http
+  seq: 11
+}
+
+post {
+  url: {{base_url}}/v2/holds
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "ids": [
+      "hold_01jv2z62f7enbsvjygch2cqye8"
+    ],
+    "owner": {
+      "type": "test_owner",
+      "id": "test_money_owner"
+    }
+  }
+}

--- a/current/holds - fetch by ids.bru
+++ b/current/holds - fetch by ids.bru
@@ -1,7 +1,7 @@
 meta {
   name: holds - fetch by ids
   type: http
-  seq: 11
+  seq: 12
 }
 
 post {

--- a/current/holds - fetch held knots.bru
+++ b/current/holds - fetch held knots.bru
@@ -1,0 +1,27 @@
+meta {
+  name: holds - fetch held knots
+  type: http
+  seq: 12
+}
+
+post {
+  url: {{base_url}}/v2/holds/knots
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "holdIds": [
+      "hold_01jv2z1pexenbsvjv2ngea65mt"
+    ],
+    "filters": {
+      "availability": "available",
+      "current": "current"
+    },
+    "owner": {
+      "type": "test_owner",
+      "id": "test_money_owner"
+    }
+  }
+}

--- a/current/holds - fetch held knots.bru
+++ b/current/holds - fetch held knots.bru
@@ -1,7 +1,7 @@
 meta {
   name: holds - fetch held knots
   type: http
-  seq: 12
+  seq: 13
 }
 
 post {

--- a/current/holds - fetch tags.bru
+++ b/current/holds - fetch tags.bru
@@ -1,0 +1,19 @@
+meta {
+  name: holds - fetch tags
+  type: http
+  seq: 13
+}
+
+post {
+  url: {{base_url}}/v2/holds/tags
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "holdIds": [
+      "hold_01jv2z1pexenbsvjv2ngea65mt"
+    ]
+  }
+}

--- a/current/holds - fetch tags.bru
+++ b/current/holds - fetch tags.bru
@@ -1,7 +1,7 @@
 meta {
   name: holds - fetch tags
   type: http
-  seq: 13
+  seq: 14
 }
 
 post {

--- a/current/holds - release.bru
+++ b/current/holds - release.bru
@@ -1,7 +1,7 @@
 meta {
   name: holds - release
   type: http
-  seq: 9
+  seq: 10
 }
 
 post {

--- a/current/holds - release.bru
+++ b/current/holds - release.bru
@@ -1,0 +1,76 @@
+meta {
+  name: holds - release
+  type: http
+  seq: 9
+}
+
+post {
+  url: {{base_url}}/v2/hold/release
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "sources": {
+      "knotIds": [
+        "knot_01jv2z1j4eenbsvjt3msr70bd3"
+      ],
+      "threadIds": [
+        // "thread_189fb9aecfb04fa88ff2ecf329c4ef96"
+      ],
+      "groupUnions": [
+        // {
+        //     "type": "crazy",
+        //     "token": "rich"
+        // },
+        // {
+        //     "id": "group_01hq1p0g2qf05tws1p21cswwea"
+        // }
+      ],
+      "groupIntersections": [
+        // [
+        //     {
+        //         "type": "crazy",
+        //         "token": "rich"
+        //     },
+        //     {
+        //         "id": "group_a69ee61425bf423cbb5647330b71c9f9"
+        //     }
+        // ]
+      ]
+    },
+    "owner": {
+      "type": "test_owner",
+      "id": "test_money_owner"
+    },
+    "holdIds": [
+      "hold_01jv2z1pexenbsvjv2ngea65mt"
+    ],
+    "actor": {
+      "type": "test_user",
+      "id": "bruno_api_test"
+    },
+    "groupsToAdd": [
+      // {
+      //     "type": "withdraw",
+      //     "token": "{{$guid}}"
+      // },
+      // {
+      //     "type": "withdraw2",
+      //     "token": "{{$guid}}"
+      // }
+    ],
+    "tags": {
+      // "a": "b",
+      // "d": "e"
+    },
+    "actionData": {
+      // "spicy": "peppers"
+    },
+    "idempotencyKey": {
+      "type": "test",
+      "token": "{{$guid}}"
+    }
+  }
+}

--- a/current/knots - allocate.bru
+++ b/current/knots - allocate.bru
@@ -1,7 +1,7 @@
 meta {
   name: knots - allocate
   type: http
-  seq: 16
+  seq: 17
 }
 
 post {

--- a/current/knots - allocate.bru
+++ b/current/knots - allocate.bru
@@ -1,0 +1,79 @@
+meta {
+  name: knots - allocate
+  type: http
+  seq: 16
+}
+
+post {
+  url: {{base_url}}/v2/knots/allocate
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "sources": {
+      "knotIds": [
+        "knot_01jv2zjqwqenbsvk3j5zd5m0ca"
+      ],
+      "threadIds": [
+        // "thread_1234"
+      ],
+      "groupUnions": [
+        // {
+        //     "id": "group_1234"
+        // }
+      ],
+      "groupIntersections": [
+        // [
+        //     {
+        //         "id": "group_1234"
+        //     }
+        // ]
+      ]
+    },
+    "filters": {
+      // "availability": "available",
+      // "holdStatus": "free",
+    },
+    "requestedAmount": {
+      "unitType": "currency_micros",
+      "unitToken": "USD",
+      "unitCount": 20000000
+    },
+    "owner": {
+      "type": "test_owner",
+      "id": "test_money_owner"
+    },
+    "actor": {
+      "type": "test_user",
+      "id": "bruno_api_test"
+    },
+    // "strategy": "smallest-largest",
+    "tags": {
+      // "sample": "tag"
+    },
+    "actionData": {
+      // "sample": "actionData"
+    },
+    "groupsToAdd": [
+      // {
+      //     "type": "allocate",
+      //     "token": "{{$guid}}"
+      // }
+    ],
+    "groupsToRemove": [
+      // {
+      //     "type": "old",
+      //     "token": "group"
+      // },
+      // {
+      //     "id": "group_1234"
+      // }
+    ],
+    "idempotencyKey": {
+      "type": "test",
+      "token": "{{$guid}}"
+    }
+  }
+}

--- a/current/knots - alter groups.bru
+++ b/current/knots - alter groups.bru
@@ -1,0 +1,74 @@
+meta {
+  name: knots - alter groups
+  type: http
+  seq: 19
+}
+
+post {
+  url: {{base_url}}/v1/knots/groups/alter
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "sources": {
+      "knotIds": [
+        "knot_01jv303qg4enbsvkdy0khxnrw8",
+        "knot_01jv304v6xenbsvkg72ry4mf3t"
+      ],
+      "threadIds": [
+        // "thread_1234"
+      ],
+      "groupUnions": [
+        // {
+        //     "id": "group_1234"
+        // }
+      ],
+      "groupIntersections": [
+        // [
+        //     {
+        //         "id": "group_1234"
+        //     }
+        // ]
+      ]
+    },
+    "filters": {
+      // "availability": "available",
+      // "holdStatus": "free",
+    },
+    "groupsToAdd": [
+      {
+        "type": "test_group_to_add",
+        "token": "test"
+      }
+    ],
+    "groupsToRemove": [
+      // {
+      //     "type": "old",
+      //     "token": "group"
+      // },
+      {
+        "id": "group_01jv304v6wenbsvkfm12rsegqh"
+      }
+    ],
+    "owner": {
+      "type": "test_owner",
+      "id": "test_money_owner"
+    },
+    "actor": {
+      "type": "test_user",
+      "id": "bruno_api_test"
+    },
+    "tags": {
+      // "sample": "tag"
+    },
+    "actionData": {
+      // "sample": "actionData"
+    },
+    "idempotencyKey": {
+      "type": "test",
+      "token": "{{$guid}}"
+    }
+  }
+}

--- a/current/knots - alter groups.bru
+++ b/current/knots - alter groups.bru
@@ -1,7 +1,7 @@
 meta {
   name: knots - alter groups
   type: http
-  seq: 19
+  seq: 20
 }
 
 post {

--- a/current/knots - alter tags.bru
+++ b/current/knots - alter tags.bru
@@ -1,7 +1,7 @@
 meta {
   name: knots - alter tags
   type: http
-  seq: 23
+  seq: 24
 }
 
 post {

--- a/current/knots - alter tags.bru
+++ b/current/knots - alter tags.bru
@@ -1,0 +1,68 @@
+meta {
+  name: knots - alter tags
+  type: http
+  seq: 23
+}
+
+post {
+  url: {{base_url}}/v1/knots/tags/alter
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "sources": {
+      "knotIds": [
+        "knot_01jv30hwbdenbsvknm3bncck64"
+      ],
+      "threadIds": [
+        // "thread_1234"
+      ],
+      "groupUnions": [
+        // {
+        //     "id": "group_1234"
+        // }
+      ],
+      "groupIntersections": [
+        // [
+        //     {
+        //         "id": "group_1234"
+        //     }
+        // ]
+      ]
+    },
+    "filters": {
+      // "availability": "available",
+      // "holdStatus": "free",
+      // "current": "current"
+    },
+    "tagsToUpdate": {
+      "key1": "value1"
+    },
+    "tagsToRemove": {
+      //         "key2": "value2"
+    },
+    "groupsToAdd": [
+      // {
+      //     "type": "group1",
+      //     "token": "test1"
+      // }
+    ],
+    "owner": {
+      "type": "test_owner",
+      "id": "test_money_owner"
+    },
+    "actor": {
+      "type": "test_user",
+      "id": "bruno_api_test"
+    },
+    "actionData": {
+      // "spicy": "peppers"
+    },
+    "idempotencyKey": {
+      "type": "test",
+      "token": "{{$guid}}"
+    }
+  }
+}

--- a/current/knots - fetch balances.bru
+++ b/current/knots - fetch balances.bru
@@ -1,7 +1,7 @@
 meta {
   name: knots - fetch balances
   type: http
-  seq: 17
+  seq: 18
 }
 
 post {

--- a/current/knots - fetch balances.bru
+++ b/current/knots - fetch balances.bru
@@ -1,0 +1,46 @@
+meta {
+  name: knots - fetch balances
+  type: http
+  seq: 17
+}
+
+post {
+  url: {{base_url}}/v2/knots/balances
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "sources": {
+      "knotIds": [
+        "knot_01jv2zkag9enbsvk535q11ygy2",
+        "knot_01jv2zkag9enbsvk4sq455cpqa"
+      ],
+      "threadIds": [
+        // "thread_1234"
+      ],
+      "groupUnions": [
+        // {
+        //     "id": "group_1234"
+        // }
+      ],
+      "groupIntersections": [
+        // [
+        //     {
+        //         "id": "group_1234"
+        //     }
+        // ]
+      ]
+    },
+    "filters": {
+      "availability": "available",
+      "holdStatus": "free"
+    },
+    "owner": {
+      "type": "test_owner",
+      "id": "test_money_owner"
+    },
+    "includeKnots": true
+  }
+}

--- a/current/knots - fetch by sources.bru
+++ b/current/knots - fetch by sources.bru
@@ -1,0 +1,38 @@
+meta {
+  name: knots - fetch by sources
+  type: http
+  seq: 15
+}
+
+post {
+  url: {{base_url}}/v2/knots
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "sources": {
+      "knotIds": [
+        "knot_01jv2zjqwqenbsvk3j5zd5m0ca"
+      ],
+      "threadIds": [],
+      "groupUnions": [
+        // {
+        //     "type": "transfer",
+        //     "token": "two-phase"
+        // }
+      ],
+      "groupIntersections": []
+    },
+    "filters": {
+      "availability": "any",
+      "current": "current",
+      "holdStatus": "any"
+    },
+    "owner": {
+      "type": "test_owner",
+      "id": "test_money_owner"
+    }
+  }
+}

--- a/current/knots - fetch by sources.bru
+++ b/current/knots - fetch by sources.bru
@@ -1,7 +1,7 @@
 meta {
   name: knots - fetch by sources
   type: http
-  seq: 15
+  seq: 16
 }
 
 post {

--- a/current/knots - fetch groups for knots.bru
+++ b/current/knots - fetch groups for knots.bru
@@ -1,7 +1,7 @@
 meta {
   name: knots - fetch groups for knots
   type: http
-  seq: 18
+  seq: 19
 }
 
 post {

--- a/current/knots - fetch groups for knots.bru
+++ b/current/knots - fetch groups for knots.bru
@@ -1,0 +1,46 @@
+meta {
+  name: knots - fetch groups for knots
+  type: http
+  seq: 18
+}
+
+post {
+  url: {{base_url}}/v2/knots/groups
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "sources": {
+      "knotIds": [
+        "knot_01jv303qg4enbsvkdy0khxnrw8",
+        "knot_01jv304v6xenbsvkg72ry4mf3t"
+      ],
+      "threadIds": [
+        // "thread_1234"
+      ],
+      "groupUnions": [
+        // {
+        //     "id": "group_01jv304v6wenbsvkfm12rsegqh"
+        // }
+      ],
+      "groupIntersections": [
+        // [
+        //     {
+        //         "id": "group_01jv304v6wenbsvkfm12rsegqh"
+        //     }
+        // ]
+      ]
+    },
+    "filters": {
+      "availability": "available",
+      "holdStatus": "any",
+      "current": "current"
+    },
+    "owner": {
+      "type": "test_owner",
+      "id": "test_money_owner"
+    }
+  }
+}

--- a/current/knots - fetch recent knots.bru
+++ b/current/knots - fetch recent knots.bru
@@ -1,7 +1,7 @@
 meta {
   name: knots - fetch recent knots
   type: http
-  seq: 20
+  seq: 21
 }
 
 post {

--- a/current/knots - fetch recent knots.bru
+++ b/current/knots - fetch recent knots.bru
@@ -1,0 +1,20 @@
+meta {
+  name: knots - fetch recent knots
+  type: http
+  seq: 20
+}
+
+post {
+  url: {{base_url}}/v2/knots/recent
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "owner": {
+      "type": "test_owner",
+      "id": "test_money_owner"
+    }
+  }
+}

--- a/current/knots - fetch tags.bru
+++ b/current/knots - fetch tags.bru
@@ -1,7 +1,7 @@
 meta {
   name: knots - fetch tags
   type: http
-  seq: 22
+  seq: 23
 }
 
 post {

--- a/current/knots - fetch tags.bru
+++ b/current/knots - fetch tags.bru
@@ -1,0 +1,45 @@
+meta {
+  name: knots - fetch tags
+  type: http
+  seq: 22
+}
+
+post {
+  url: {{base_url}}/v2/knots/tags
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "sources": {
+      "knotIds": [
+        "knot_01jv30hwbdenbsvkpe257nhp45"
+      ],
+      "threadIds": [
+        // "thread_1234"
+      ],
+      "groupUnions": [
+        // {
+        //     "id": "group_1234"
+        // }
+      ],
+      "groupIntersections": [
+        // [
+        //     {
+        //         "id": "group_1234"
+        //     }
+        // ]
+      ]
+    },
+    "filters": {
+      // "availability": "available",
+      // "holdStatus": "free",
+      // "current": "current"
+    },
+    "owner": {
+      "type": "test_owner",
+      "id": "test_money_owner"
+    }
+  }
+}

--- a/current/knots - search.bru
+++ b/current/knots - search.bru
@@ -1,0 +1,26 @@
+meta {
+  name: knots - search
+  type: http
+  seq: 21
+}
+
+post {
+  url: {{base_url}}/v2/knots/search
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "term": "USD",
+    "filters": {
+      "availability": "available",
+      "holdStatus": "free",
+      "current": "current"
+    },
+    "owner": {
+      "type": "test_owner",
+      "id": "test_money_owner"
+    }
+  }
+}

--- a/current/knots - search.bru
+++ b/current/knots - search.bru
@@ -1,7 +1,7 @@
 meta {
   name: knots - search
   type: http
-  seq: 21
+  seq: 22
 }
 
 post {

--- a/current/knots - trace.bru
+++ b/current/knots - trace.bru
@@ -1,0 +1,45 @@
+meta {
+  name: knots - trace
+  type: http
+  seq: 24
+}
+
+post {
+  url: {{base_url}}/v2/knots/trace
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "sources": {
+      "knotIds": [
+        "knot_01jv30hwbdenbsvkpe257nhp45"
+      ],
+      "threadIds": [
+        // "thread_1234"
+      ],
+      "groupUnions": [
+        // {
+        //     "id": "group_1234"
+        // }
+      ],
+      "groupIntersections": [
+        // [
+        //     {
+        //         "id": "group_1234"
+        //     }
+        // ]
+      ]
+    },
+    "filters": {
+      // "availability": "available",
+      // "holdStatus": "free",
+      // "current": "current"
+    },
+    "owner": {
+      "type": "test_owner",
+      "id": "test_money_owner"
+    }
+  }
+}

--- a/current/knots - trace.bru
+++ b/current/knots - trace.bru
@@ -1,7 +1,7 @@
 meta {
   name: knots - trace
   type: http
-  seq: 24
+  seq: 25
 }
 
 post {

--- a/current/loan - from groups.bru
+++ b/current/loan - from groups.bru
@@ -1,0 +1,59 @@
+meta {
+  name: loan - from groups
+  type: http
+  seq: 25
+}
+
+post {
+  url: {{base_url}}/v2/loan/group
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "source": {
+      "groupIntersection": [
+        {
+          "type": "test_group_type_token",
+          "token": "a14d2e2e-230a-4271-a4f4-9b7253dbbce1"
+        }
+      ],
+      "owner": {
+        "type": "test_owner",
+        "id": "test_money_owner"
+      }
+    },
+    "destination": {
+      "owner": {
+        "type": "test_owner",
+        "id": "destination_owner"
+      },
+      "tags": {
+        // "sample": "tag"
+      },
+      "groupsToAdd": [
+        // {
+        //     "type": "allocate",
+        //     "token": "{{$guid}}"
+        // }
+      ]
+    },
+    "amount": {
+      "unitType": "currency_micros",
+      "unitToken": "USD",
+      "unitCount": 20000000
+    },
+    "actor": {
+      "type": "test_user",
+      "id": "bruno_api_test"
+    },
+    "actionData": {
+      // "sample": "actionData"
+    },
+    "idempotencyKey": {
+      "type": "test",
+      "token": "{{$guid}}"
+    }
+  }
+}

--- a/current/loan - from groups.bru
+++ b/current/loan - from groups.bru
@@ -1,7 +1,7 @@
 meta {
   name: loan - from groups
   type: http
-  seq: 25
+  seq: 26
 }
 
 post {

--- a/current/loan - from knots.bru
+++ b/current/loan - from knots.bru
@@ -1,7 +1,7 @@
 meta {
   name: loan - from knots
   type: http
-  seq: 26
+  seq: 27
 }
 
 post {

--- a/current/loan - from knots.bru
+++ b/current/loan - from knots.bru
@@ -1,0 +1,51 @@
+meta {
+  name: loan - from knots
+  type: http
+  seq: 26
+}
+
+post {
+  url: {{base_url}}/v2/loan/knots
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "source": {
+      "knotIds": [
+        "knot_01jv3132cmenbsvm48msbhfvzj"
+      ],
+      "owner": {
+        "type": "test_owner",
+        "id": "destination_owner"
+      }
+    },
+    "destination": {
+      "owner": {
+        "type": "test_owner",
+        "id": "test_money_owner"
+      },
+      "tags": {
+        // "sample": "tag"
+      },
+      "groupsToAdd": [
+        // {
+        //     "type": "allocate",
+        //     "token": "{{$guid}}"
+        // }
+      ]
+    },
+    "actor": {
+      "type": "test_user",
+      "id": "bruno_api_test"
+    },
+    "actionData": {
+      // "sample": "actionData"
+    },
+    "idempotencyKey": {
+      "type": "test",
+      "token": "{{$guid}}"
+    }
+  }
+}

--- a/current/owner - fetch balances.bru
+++ b/current/owner - fetch balances.bru
@@ -1,0 +1,21 @@
+meta {
+  name: owner - fetch balances
+  type: http
+  seq: 27
+}
+
+post {
+  url: {{base_url}}/v1/owner/balances
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "owner": {
+      "type": "test_owner",
+      "id": "test_money_owner"
+    },
+    "includeKnots": true
+  }
+}

--- a/current/owner - fetch balances.bru
+++ b/current/owner - fetch balances.bru
@@ -1,7 +1,7 @@
 meta {
   name: owner - fetch balances
   type: http
-  seq: 27
+  seq: 28
 }
 
 post {

--- a/current/repay - from groups.bru
+++ b/current/repay - from groups.bru
@@ -1,7 +1,7 @@
 meta {
   name: repay - from groups
   type: http
-  seq: 28
+  seq: 29
 }
 
 post {

--- a/current/repay - from groups.bru
+++ b/current/repay - from groups.bru
@@ -1,0 +1,59 @@
+meta {
+  name: repay - from groups
+  type: http
+  seq: 28
+}
+
+post {
+  url: {{base_url}}/v2/repay/group
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "source": {
+      "positiveKnotIntersection": [
+        {
+          "id": "group_01jv315k93enbsvmbc93hs5ms0"
+        }
+      ],
+      "debtKnotIntersection": [
+        {
+          "id": "group_01jv315k93enbsvmbc93hs5ms0"
+        }
+      ],
+      "owner": {
+        "type": "test_owner",
+        "id": "test_money_owner"
+      }
+    },
+    "destination": {
+      "owner": {
+        "type": "test_owner",
+        "id": "destination_owner"
+      },
+      "tags": {
+        // "sample": "tag"
+      },
+      "groupsToAdd": [
+        // {
+        //     "type": "allocate",
+        //     "token": "{{$guid}}"
+        // }
+      ]
+    },
+    "actor": {
+      "type": "test_user",
+      "id": "bruno_api_test"
+    },
+    // "repaymentStrategy": "exact",
+    "actionData": {
+      // "sample": "actionData"
+    },
+    "idempotencyKey": {
+      "type": "test",
+      "token": "{{$guid}}"
+    }
+  }
+}

--- a/current/repay - from knots.bru
+++ b/current/repay - from knots.bru
@@ -1,0 +1,55 @@
+meta {
+  name: repay - from knots
+  type: http
+  seq: 29
+}
+
+post {
+  url: {{base_url}}/v2/repay/knots
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "source": {
+      "positiveKnotIds": [
+        "knot_01jv31bxpgenbsvmped0ej1xms"
+      ],
+      "debtKnotIds": [
+        "knot_01jv3132cmenbsvm6cx03ckwvm"
+      ],
+      "owner": {
+        "type": "test_owner",
+        "id": "destination_owner"
+      }
+    },
+    "destination": {
+      "owner": {
+        "type": "test_owner",
+        "id": "test_money_owner"
+      },
+      "tags": {
+        // "sample": "tag"
+      },
+      "groupsToAdd": [
+        // {
+        //     "type": "allocate",
+        //     "token": "{{$guid}}"
+        // }
+      ]
+    },
+    "actor": {
+      "type": "test_user",
+      "id": "bruno_api_test"
+    },
+    // "repaymentStrategy": "exact",
+    "actionData": {
+      // "sample": "actionData"
+    },
+    "idempotencyKey": {
+      "type": "test",
+      "token": "{{$guid}}"
+    }
+  }
+}

--- a/current/repay - from knots.bru
+++ b/current/repay - from knots.bru
@@ -1,7 +1,7 @@
 meta {
   name: repay - from knots
   type: http
-  seq: 29
+  seq: 30
 }
 
 post {

--- a/current/return - cancel.bru
+++ b/current/return - cancel.bru
@@ -1,0 +1,60 @@
+meta {
+  name: return - cancel
+  type: http
+  seq: 34
+}
+
+post {
+  url: {{base_url}}/v2/return/cancel
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "sources": {
+      "knotIds": [
+        "knot_01jv32jjm3enbsvpgfkjavyzfc"
+      ],
+      "threadIds": [
+        // "thread_1234"
+      ],
+      "groupUnions": [
+        // {
+        //     "id": "group_1234"
+        // }
+      ],
+      "groupIntersections": [
+        // [
+        //     {
+        //         "id": "group_1234"
+        //     }
+        // ]
+      ]
+    },
+    "owner": {
+      "type": "test_owner",
+      "id": "test_money_owner"
+    },
+    "actor": {
+      "type": "test_user",
+      "id": "bruno_api_test"
+    },
+    "tags": {
+      // "sample": "tag"
+    },
+    "groupsToAdd": [
+      // {
+      //     "type": "allocate",
+      //     "token": "{{$guid}}"
+      // }
+    ],
+    "actionData": {
+      // "sample": "actionData"
+    },
+    "idempotencyKey": {
+      "type": "test",
+      "token": "{{$guid}}"
+    }
+  }
+}

--- a/current/return - confirm.bru
+++ b/current/return - confirm.bru
@@ -1,0 +1,60 @@
+meta {
+  name: return - confirm
+  type: http
+  seq: 33
+}
+
+post {
+  url: {{base_url}}/v2/return/confirm
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "sources": {
+      "knotIds": [
+        "knot_01jv32eyvzenbsvp6cn01p6gsk"
+      ],
+      "threadIds": [
+        // "thread_1234"
+      ],
+      "groupUnions": [
+        // {
+        //     "id": "group_1234"
+        // }
+      ],
+      "groupIntersections": [
+        // [
+        //     {
+        //         "id": "group_1234"
+        //     }
+        // ]
+      ]
+    },
+    "owner": {
+      "type": "test_owner",
+      "id": "test_money_owner"
+    },
+    "actor": {
+      "type": "test_user",
+      "id": "bruno_api_test"
+    },
+    "tags": {
+      // "sample": "tag"
+    },
+    "groupsToAdd": [
+      // {
+      //     "type": "allocate",
+      //     "token": "{{$guid}}"
+      // }
+    ],
+    "actionData": {
+      // "sample": "actionData"
+    },
+    "idempotencyKey": {
+      "type": "test",
+      "token": "{{$guid}}"
+    }
+  }
+}

--- a/current/return - pending.bru
+++ b/current/return - pending.bru
@@ -1,0 +1,65 @@
+meta {
+  name: return - pending
+  type: http
+  seq: 32
+}
+
+post {
+  url: {{base_url}}/v2/return/pending
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "sources": {
+      "knotIds": [
+        "knot_01jv32jbv8enbsvpcwcte47b4z"
+      ],
+      "threadIds": [
+        // "thread_1234"
+      ],
+      "groupUnions": [
+        // {
+        //     "id": "group_1234"
+        // }
+      ],
+      "groupIntersections": [
+        // [
+        //     {
+        //         "id": "group_1234"
+        //     }
+        // ]
+      ]
+    },
+    "amount": {
+      "unitType": "currency_micros",
+      "unitToken": "USD",
+      "unitCount": 200
+    },
+    "owner": {
+      "type": "test_owner",
+      "id": "test_money_owner"
+    },
+    "actor": {
+      "type": "test_user",
+      "id": "bruno_api_test"
+    },
+    "tags": {
+      // "sample": "tag"
+    },
+    "groupsToAdd": [
+      // {
+      //     "type": "allocate",
+      //     "token": "{{$guid}}"
+      // }
+    ],
+    "actionData": {
+      // "sample": "actionData"
+    },
+    "idempotencyKey": {
+      "type": "test",
+      "token": "{{$guid}}"
+    }
+  }
+}

--- a/current/return.bru
+++ b/current/return.bru
@@ -1,0 +1,65 @@
+meta {
+  name: return
+  type: http
+  seq: 31
+}
+
+post {
+  url: {{base_url}}/v2/return
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "sources": {
+      "knotIds": [
+        "knot_01jv31q4exenbsvn2ffxtypetj"
+      ],
+      "threadIds": [
+        // "thread_1234"
+      ],
+      "groupUnions": [
+        // {
+        //     "id": "group_1234"
+        // }
+      ],
+      "groupIntersections": [
+        // [
+        //     {
+        //         "id": "group_1234"
+        //     }
+        // ]
+      ]
+    },
+    "amount": {
+      "unitType": "currency_micros",
+      "unitToken": "USD",
+      "unitCount": 20000
+    },
+    "owner": {
+      "type": "test_owner",
+      "id": "test_money_owner"
+    },
+    "actor": {
+      "type": "test_user",
+      "id": "bruno_api_test"
+    },
+    "tags": {
+      // "sample": "tag"
+    },
+    "groupsToAdd": [
+      // {
+      //     "type": "allocate",
+      //     "token": "{{$guid}}"
+      // }
+    ],
+    "actionData": {
+      // "sample": "actionData"
+    },
+    "idempotencyKey": {
+      "type": "test",
+      "token": "{{$guid}}"
+    }
+  }
+}

--- a/current/threads - fetch by id.bru
+++ b/current/threads - fetch by id.bru
@@ -1,0 +1,23 @@
+meta {
+  name: threads - fetch by id
+  type: http
+  seq: 35
+}
+
+post {
+  url: {{base_url}}/v2/threads
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "threadIds": [
+      "thread_01jv32j5abenbsvp9gd9chrkb2"
+    ],
+    "owner": {
+      "type": "test_owner",
+      "id": "test_money_owner"
+    }
+  }
+}

--- a/current/transfer - from groups.bru
+++ b/current/transfer - from groups.bru
@@ -1,0 +1,59 @@
+meta {
+  name: transfer - from groups
+  type: http
+  seq: 36
+}
+
+post {
+  url: {{base_url}}/v2/transfer/group
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "source": {
+      "groupIntersection": [
+          {
+            "type": "test_group_type_token",
+            "token": "a14d2e2e-230a-4271-a4f4-9b7253dbbce1"
+          }
+      ],
+      "owner": {
+        "type": "test_owner",
+        "id": "test_money_owner"
+      }
+    },
+    "destination": {
+      "owner": {
+        "type": "test_owner",
+        "id": "destination_owner"
+      },
+      "tags": {
+        // "sample": "tag"
+      },
+      "groupsToAdd": [
+        // {
+        //     "type": "allocate",
+        //     "token": "{{$guid}}"
+        // }
+      ]
+    },
+    "amount": {
+      "unitType": "currency_micros",
+      "unitToken": "USD",
+      "unitCount": 20000000
+    },
+    "actor": {
+      "type": "test_user",
+      "id": "bruno_api_test"
+    },
+    "actionData": {
+      // "sample": "actionData"
+    },
+    "idempotencyKey": {
+      "type": "test",
+      "token": "{{$guid}}"
+    }
+  }
+}

--- a/current/transfer - from knots.bru
+++ b/current/transfer - from knots.bru
@@ -1,0 +1,51 @@
+meta {
+  name: transfer - from knots
+  type: http
+  seq: 37
+}
+
+post {
+  url: {{base_url}}/v2/transfer/knots
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "source": {
+      "knotIds": [
+        "knot_01jv32vkjsenbsvpt7g2d1grs5"
+      ],
+      "owner": {
+        "type": "test_owner",
+        "id": "test_money_owner"
+      }
+    },
+    "destination": {
+      "owner": {
+        "type": "test_owner",
+        "id": "destination_owner"
+      },
+      "tags": {
+        // "sample": "tag"
+      },
+      "groupsToAdd": [
+        // {
+        //     "type": "allocate",
+        //     "token": "{{$guid}}"
+        // }
+      ]
+    },
+    "actor": {
+      "type": "test_user",
+      "id": "bruno_api_test"
+    },
+    "actionData": {
+      // "sample": "actionData"
+    },
+    "idempotencyKey": {
+      "type": "test",
+      "token": "{{$guid}}"
+    }
+  }
+}

--- a/current/withdraw - cancel.bru
+++ b/current/withdraw - cancel.bru
@@ -1,7 +1,7 @@
 meta {
   name: withdraw - cancel
   type: http
-  seq: 37
+  seq: 40
 }
 
 post {

--- a/current/withdraw - cancel.bru
+++ b/current/withdraw - cancel.bru
@@ -1,7 +1,7 @@
 meta {
   name: withdraw - cancel
   type: http
-  seq: 33
+  seq: 37
 }
 
 post {

--- a/current/withdraw - cancel.bru
+++ b/current/withdraw - cancel.bru
@@ -1,7 +1,7 @@
 meta {
   name: withdraw - cancel
   type: http
-  seq: 32
+  seq: 33
 }
 
 post {

--- a/current/withdraw - cancel.bru
+++ b/current/withdraw - cancel.bru
@@ -1,0 +1,73 @@
+meta {
+  name: withdraw - cancel
+  type: http
+  seq: 32
+}
+
+post {
+  url: {{base_url}}/v2/withdraw/cancel
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "sources": {
+      "knotIds": [
+        "knot_01jv31sdnhenbsvn584k76agx3"
+      ],
+      "threadIds": [
+        // "thread_189fb9aecfb04fa88ff2ecf329c4ef96"
+      ],
+      "groupUnions": [
+        // {
+        //     "type": "crazy",
+        //     "token": "rich"
+        // },
+        // {
+        //     "id": "group_01hq1p0g2qf05tws1p21cswwea"
+        // }
+      ],
+      "groupIntersections": [
+        // [
+        //     {
+        //         "type": "crazy",
+        //         "token": "rich"
+        //     },
+        //     {
+        //         "id": "group_a69ee61425bf423cbb5647330b71c9f9"
+        //     }
+        // ]
+      ]
+    },
+    "owner": {
+      "type": "test_owner",
+      "id": "test_money_owner"
+    },
+    "actor": {
+      "type": "test_user",
+      "id": "bruno_api_test"
+    },
+    "groupsToAdd": [
+      // {
+      //     "type": "withdraw",
+      //     "token": "{{$guid}}"
+      // },
+      // {
+      //     "type": "withdraw2",
+      //     "token": "{{$guid}}"
+      // }
+    ],
+    "tags": {
+      // "a": "b",
+      // "d": "e"
+    },
+    "actionData": {
+      // "spicy": "peppers"
+    },
+    "idempotencyKey": {
+      "type": "test",
+      "token": "{{$guid}}"
+    }
+  }
+}

--- a/current/withdraw - confirm.bru
+++ b/current/withdraw - confirm.bru
@@ -1,0 +1,73 @@
+meta {
+  name: withdraw - confirm
+  type: http
+  seq: 33
+}
+
+post {
+  url: {{base_url}}/v2/withdraw/confirm
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "sources": {
+      "knotIds": [
+        "knot_01jv31x2aqenbsvnc85gkj3tzx"
+      ],
+      "threadIds": [
+        // "thread_189fb9aecfb04fa88ff2ecf329c4ef96"
+      ],
+      "groupUnions": [
+        // {
+        //     "type": "crazy",
+        //     "token": "rich"
+        // },
+        // {
+        //     "id": "group_01hq1p0g2qf05tws1p21cswwea"
+        // }
+      ],
+      "groupIntersections": [
+        // [
+        //     {
+        //         "type": "crazy",
+        //         "token": "rich"
+        //     },
+        //     {
+        //         "id": "group_a69ee61425bf423cbb5647330b71c9f9"
+        //     }
+        // ]
+      ]
+    },
+    "owner": {
+      "type": "test_owner",
+      "id": "test_money_owner"
+    },
+    "actor": {
+      "type": "test_user",
+      "id": "bruno_api_test"
+    },
+    "groupsToAdd": [
+      // {
+      //     "type": "withdraw",
+      //     "token": "{{$guid}}"
+      // },
+      // {
+      //     "type": "withdraw2",
+      //     "token": "{{$guid}}"
+      // }
+    ],
+    "tags": {
+      // "a": "b",
+      // "d": "e"
+    },
+    "actionData": {
+      // "spicy": "peppers"
+    },
+    "idempotencyKey": {
+      "type": "test",
+      "token": "{{$guid}}"
+    }
+  }
+}

--- a/current/withdraw - confirm.bru
+++ b/current/withdraw - confirm.bru
@@ -1,7 +1,7 @@
 meta {
   name: withdraw - confirm
   type: http
-  seq: 38
+  seq: 41
 }
 
 post {

--- a/current/withdraw - confirm.bru
+++ b/current/withdraw - confirm.bru
@@ -1,7 +1,7 @@
 meta {
   name: withdraw - confirm
   type: http
-  seq: 34
+  seq: 38
 }
 
 post {

--- a/current/withdraw - confirm.bru
+++ b/current/withdraw - confirm.bru
@@ -1,7 +1,7 @@
 meta {
   name: withdraw - confirm
   type: http
-  seq: 33
+  seq: 34
 }
 
 post {

--- a/current/withdraw - debt pending.bru
+++ b/current/withdraw - debt pending.bru
@@ -1,7 +1,7 @@
 meta {
   name: withdraw - debt pending
   type: http
-  seq: 36
+  seq: 40
 }
 
 post {

--- a/current/withdraw - debt pending.bru
+++ b/current/withdraw - debt pending.bru
@@ -1,11 +1,11 @@
 meta {
-  name: withdraw
+  name: withdraw - debt pending
   type: http
-  seq: 31
+  seq: 36
 }
 
 post {
-  url: {{base_url}}/v2/withdraw
+  url: {{base_url}}/v2/withdraw/pending/debt
   body: json
   auth: inherit
 }
@@ -14,7 +14,7 @@ body:json {
   {
     "sources": {
       "knotIds": [
-        "knot_01jv31mpq2enbsvmz9jneqkqxa"
+        "knot_01jv326h1genbsvnrpavhb9e2z"
       ],
       "threadIds": [
         // "thread_189fb9aecfb04fa88ff2ecf329c4ef96"
@@ -41,7 +41,7 @@ body:json {
       ]
     },
     "amount": {
-      "unitCount": 50000,
+      "unitCount": -50000,
       "unitType": "currency_micros",
       "unitToken": "USD"
     },

--- a/current/withdraw - debt pending.bru
+++ b/current/withdraw - debt pending.bru
@@ -1,7 +1,7 @@
 meta {
   name: withdraw - debt pending
   type: http
-  seq: 40
+  seq: 43
 }
 
 post {

--- a/current/withdraw - debt.bru
+++ b/current/withdraw - debt.bru
@@ -1,0 +1,73 @@
+meta {
+  name: withdraw - debt
+  type: http
+  seq: 34
+}
+
+post {
+  url: {{base_url}}/v2/withdraw/confirm
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "sources": {
+      "knotIds": [
+        "knot_01jv31x2aqenbsvnc85gkj3tzx"
+      ],
+      "threadIds": [
+        // "thread_189fb9aecfb04fa88ff2ecf329c4ef96"
+      ],
+      "groupUnions": [
+        // {
+        //     "type": "crazy",
+        //     "token": "rich"
+        // },
+        // {
+        //     "id": "group_01hq1p0g2qf05tws1p21cswwea"
+        // }
+      ],
+      "groupIntersections": [
+        // [
+        //     {
+        //         "type": "crazy",
+        //         "token": "rich"
+        //     },
+        //     {
+        //         "id": "group_a69ee61425bf423cbb5647330b71c9f9"
+        //     }
+        // ]
+      ]
+    },
+    "owner": {
+      "type": "test_owner",
+      "id": "test_money_owner"
+    },
+    "actor": {
+      "type": "test_user",
+      "id": "bruno_api_test"
+    },
+    "groupsToAdd": [
+      // {
+      //     "type": "withdraw",
+      //     "token": "{{$guid}}"
+      // },
+      // {
+      //     "type": "withdraw2",
+      //     "token": "{{$guid}}"
+      // }
+    ],
+    "tags": {
+      // "a": "b",
+      // "d": "e"
+    },
+    "actionData": {
+      // "spicy": "peppers"
+    },
+    "idempotencyKey": {
+      "type": "test",
+      "token": "{{$guid}}"
+    }
+  }
+}

--- a/current/withdraw - debt.bru
+++ b/current/withdraw - debt.bru
@@ -1,7 +1,7 @@
 meta {
   name: withdraw - debt
   type: http
-  seq: 39
+  seq: 42
 }
 
 post {

--- a/current/withdraw - debt.bru
+++ b/current/withdraw - debt.bru
@@ -1,11 +1,11 @@
 meta {
   name: withdraw - debt
   type: http
-  seq: 34
+  seq: 35
 }
 
 post {
-  url: {{base_url}}/v2/withdraw/confirm
+  url: {{base_url}}/v2/withdraw/debt
   body: json
   auth: inherit
 }
@@ -14,7 +14,7 @@ body:json {
   {
     "sources": {
       "knotIds": [
-        "knot_01jv31x2aqenbsvnc85gkj3tzx"
+        "knot_01jv323xttenbsvnk0bfgp6yah"
       ],
       "threadIds": [
         // "thread_189fb9aecfb04fa88ff2ecf329c4ef96"
@@ -39,6 +39,11 @@ body:json {
         //     }
         // ]
       ]
+    },
+    "amount": {
+      "unitCount": -50000,
+      "unitType": "currency_micros",
+      "unitToken": "USD"
     },
     "owner": {
       "type": "test_owner",

--- a/current/withdraw - debt.bru
+++ b/current/withdraw - debt.bru
@@ -1,7 +1,7 @@
 meta {
   name: withdraw - debt
   type: http
-  seq: 35
+  seq: 39
 }
 
 post {

--- a/current/withdraw - pending.bru
+++ b/current/withdraw - pending.bru
@@ -1,7 +1,7 @@
 meta {
   name: withdraw - pending
   type: http
-  seq: 36
+  seq: 39
 }
 
 post {

--- a/current/withdraw - pending.bru
+++ b/current/withdraw - pending.bru
@@ -1,7 +1,7 @@
 meta {
   name: withdraw - pending
   type: http
-  seq: 31
+  seq: 32
 }
 
 post {

--- a/current/withdraw - pending.bru
+++ b/current/withdraw - pending.bru
@@ -25,10 +25,6 @@ body:json {
         //     "token": "rich"
         // },
         // {
-        //     "type": "gusto_float",
-        //     "token": "d712d750-0eb5-4553-84c0-c5b09f78707b"
-        // }
-        // {
         //     "id": "group_01hq1p0g2qf05tws1p21cswwea"
         // }
       ],

--- a/current/withdraw - pending.bru
+++ b/current/withdraw - pending.bru
@@ -1,0 +1,82 @@
+meta {
+  name: withdraw - pending
+  type: http
+  seq: 31
+}
+
+post {
+  url: {{base_url}}/v2/withdraw/pending
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "sources": {
+      "knotIds": [
+        "knot_01jv31wwsdenbsvn99pr6750nk"
+      ],
+      "threadIds": [
+        // "thread_189fb9aecfb04fa88ff2ecf329c4ef96"
+      ],
+      "groupUnions": [
+        // {
+        //     "type": "crazy",
+        //     "token": "rich"
+        // },
+        // {
+        //     "type": "gusto_float",
+        //     "token": "d712d750-0eb5-4553-84c0-c5b09f78707b"
+        // }
+        // {
+        //     "id": "group_01hq1p0g2qf05tws1p21cswwea"
+        // }
+      ],
+      "groupIntersections": [
+        // [
+        //     {
+        //         "type": "crazy",
+        //         "token": "rich"
+        //     },
+        //     {
+        //         "id": "group_a69ee61425bf423cbb5647330b71c9f9"
+        //     }
+        // ]
+      ]
+    },
+    "amount": {
+      "unitCount": 5000,
+      "unitType": "currency_micros",
+      "unitToken": "USD"
+    },
+    "owner": {
+      "type": "test_owner",
+      "id": "test_money_owner"
+    },
+    "actor": {
+      "type": "test_user",
+      "id": "bruno_api_test"
+    },
+    "groupsToAdd": [
+      // {
+      //     "type": "withdraw",
+      //     "token": "{{$guid}}"
+      // },
+      // {
+      //     "type": "withdraw2",
+      //     "token": "{{$guid}}"
+      // }
+    ],
+    "tags": {
+      // "a": "b",
+      // "d": "e"
+    },
+    "actionData": {
+      // "spicy": "peppers"
+    },
+    "idempotencyKey": {
+      "type": "test",
+      "token": "{{$guid}}"
+    }
+  }
+}

--- a/current/withdraw - pending.bru
+++ b/current/withdraw - pending.bru
@@ -1,7 +1,7 @@
 meta {
   name: withdraw - pending
   type: http
-  seq: 32
+  seq: 36
 }
 
 post {

--- a/current/withdraw.bru
+++ b/current/withdraw.bru
@@ -1,7 +1,7 @@
 meta {
   name: withdraw
   type: http
-  seq: 31
+  seq: 35
 }
 
 post {

--- a/current/withdraw.bru
+++ b/current/withdraw.bru
@@ -1,0 +1,78 @@
+meta {
+  name: withdraw
+  type: http
+  seq: 30
+}
+
+post {
+  url: {{base_url}}/v2/withdraw
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "sources": {
+      "knotIds": [
+        "knot_01jv31mpq2enbsvmz9jneqkqxa"
+      ],
+      "threadIds": [
+        // "thread_189fb9aecfb04fa88ff2ecf329c4ef96"
+      ],
+      "groupUnions": [
+        // {
+        //     "type": "crazy",
+        //     "token": "rich"
+        // },
+        // {
+        //     "id": "group_01hq1p0g2qf05tws1p21cswwea"
+        // }
+      ],
+      "groupIntersections": [
+        // [
+        //     {
+        //         "type": "crazy",
+        //         "token": "rich"
+        //     },
+        //     {
+        //         "id": "group_a69ee61425bf423cbb5647330b71c9f9"
+        //     }
+        // ]
+      ]
+    },
+    "amount": {
+      "unitCount": 50000,
+      "unitType": "currency_micros",
+      "unitToken": "USD"
+    },
+    "owner": {
+      "type": "test_owner",
+      "id": "test_money_owner"
+    },
+    "actor": {
+      "type": "test_user",
+      "id": "bruno_api_test"
+    },
+    "groupsToAdd": [
+      // {
+      //     "type": "withdraw",
+      //     "token": "{{$guid}}"
+      // },
+      // {
+      //     "type": "withdraw2",
+      //     "token": "{{$guid}}"
+      // }
+    ],
+    "tags": {
+      // "a": "b",
+      // "d": "e"
+    },
+    "actionData": {
+      // "spicy": "peppers"
+    },
+    "idempotencyKey": {
+      "type": "test",
+      "token": "{{$guid}}"
+    }
+  }
+}

--- a/current/withdraw.bru
+++ b/current/withdraw.bru
@@ -1,7 +1,7 @@
 meta {
   name: withdraw
   type: http
-  seq: 35
+  seq: 38
 }
 
 post {

--- a/operational/api docs.bru
+++ b/operational/api docs.bru
@@ -1,0 +1,11 @@
+meta {
+  name: api docs
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{base_url}}/api
+  body: none
+  auth: inherit
+}

--- a/operational/folder.bru
+++ b/operational/folder.bru
@@ -1,0 +1,7 @@
+meta {
+  name: operational
+}
+
+headers {
+  x-api-key: {{api_key}}
+}

--- a/operational/health check.bru
+++ b/operational/health check.bru
@@ -1,0 +1,11 @@
+meta {
+  name: health check
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{base_url}}/health
+  body: none
+  auth: inherit
+}


### PR DESCRIPTION
This PR ports over `current`, `beta`, and `operational` endpoints from postman. It doesn't have any `supported` endpoints, because there are none right now. I also didn't migrate `deprecated` because I didn't see a reason to.